### PR TITLE
fixed negative weight for network plot

### DIFF
--- a/R/plotA.R
+++ b/R/plotA.R
@@ -131,6 +131,8 @@ plotA<-function(A, method="image", header="", scale.weight=FALSE, original=FALSE
     # attributes can be placed in plot also, but this has the advantage of easier transfer to tkplot, see http://kateto.net/network-visualization
     E(g)$arrow.size=0.3
     E(g)$color=colors
+    E(g)$weight.org=E(g)$weight
+    E(g)$weight=abs(E(g)$weight)
     V(g)$color="white"
     V(g)$label=taxonnames
     V(g)$frame.color="black"

--- a/R/plotA.R
+++ b/R/plotA.R
@@ -131,15 +131,13 @@ plotA<-function(A, method="image", header="", scale.weight=FALSE, original=FALSE
     # attributes can be placed in plot also, but this has the advantage of easier transfer to tkplot, see http://kateto.net/network-visualization
     E(g)$arrow.size=0.3
     E(g)$color=colors
-    E(g)$weight.org=E(g)$weight
-    E(g)$weight=abs(E(g)$weight)
     V(g)$color="white"
     V(g)$label=taxonnames
     V(g)$frame.color="black"
     V(g)$label.color="black"
     # alternative: https://www.ggplot2-exts.org/ggraph.html
     # http://kateto.net/network-visualization
-    plot(g,layout=layout.fruchterman.reingold(g))
+    plot(g,layout=layout.fruchterman.reingold(g, weights=abs(E(g)$weight)))
     if(returnNetwork==TRUE){
       return(g)
     }


### PR DESCRIPTION
The network plot in `plotA` from the [tutorial](https://hallucigenia-sparsa.github.io/seqtime/articles/network_inference.html) does not work with the current igraph version:
```R
library(seqtime)
N=20
A=generateA(N, c=0.1)
rownames(A)=c(1:N)
colnames(A)=rownames(A)
network=plotA(A,method="network")

Error in layout_with_fr(list(20, TRUE, c(0, 0, 0, 1, 1, 1, 2, 3, 3, 4,  : 
  At core/layout/fruchterman_reingold.c:401 : Weights must be positive for Fruchterman-Reingold layout. Invalid value
```
The Fruchterman-Reingold layout in igraph needs weights > 0 (see https://igraph.org/r/doc/layout_with_fr.html).

The pull request uses absolute values instead and saves old values as `weight.org`.